### PR TITLE
Added args for input tests

### DIFF
--- a/Runtime/CurrentSettings.cs
+++ b/Runtime/CurrentSettings.cs
@@ -77,4 +77,6 @@ public class CurrentSettings : ScriptableObject
     public string UrpPaCascade4Split;
     public float UrpShadowDepthBias;
     public float UrpShadowNormalBias;
+    public string XrInputActionsFile;
+    public string XrInputDeviceInfoFile;
 }

--- a/Runtime/CustomMetadataManager.cs
+++ b/Runtime/CustomMetadataManager.cs
@@ -180,7 +180,9 @@ namespace com.unity.test.metadatamanager
                     new KeyValuePair<string, string>("UrpShadowDepthBias",
                         Instance.UrpShadowDepthBias.ToString(CultureInfo.InvariantCulture)),
                     new KeyValuePair<string, string>("UrpShadowNormalBias",
-                        Instance.UrpShadowNormalBias.ToString(CultureInfo.InvariantCulture))
+                        Instance.UrpShadowNormalBias.ToString(CultureInfo.InvariantCulture)),
+                    new KeyValuePair<string, string>("XrInputActionsFile", Instance.XrInputActionsFile),
+                    new KeyValuePair<string, string>("XrInputDeviceInfoFile", Instance.XrInputDeviceInfoFile)
                 };
 
                 UpdateMetadataWithMatchesInTestContext(customMetaData);


### PR DESCRIPTION
There are a couple custom arguments we need for some of our input test functionality. This PR is simply to add them to the metadatamanager so they can be accessed as needed.